### PR TITLE
Update dialSCTPExtConfig in sctp_unsupported.go

### DIFF
--- a/sctp_unsupported.go
+++ b/sctp_unsupported.go
@@ -95,6 +95,6 @@ func DialSCTPExt(network string, laddr, raddr *SCTPAddr, options InitMsg) (*SCTP
 	return nil, ErrUnsupported
 }
 
-func dialSCTPExtConfig(network string, laddr, raddr *SCTPAddr, options InitMsg, control func(network, address string, c syscall.RawConn) error) (*SCTPConn, error) {
+func dialSCTPExtConfig(network string, laddr, raddr *SCTPAddr, options InitMsg, block bool, control func(network, address string, c syscall.RawConn) error) (*SCTPConn, error) {
 	return nil, ErrUnsupported
 }


### PR DESCRIPTION
Modified so that the arguments are the same as dialSCTPExtConfig defined in sctp_linux.go.